### PR TITLE
Fix for ACF 5.9.0

### DIFF
--- a/src/AcfBlockServiceProvider.php
+++ b/src/AcfBlockServiceProvider.php
@@ -48,7 +48,7 @@ class AcfBlockServiceProvider extends ServiceProvider
             wp_register_script(
                 'sage/acf-blocks.js',
                 $this->app['acfblock']->uri(__DIR__ . '/acf-blocks.js'),
-                ['acf-blocks', 'wp-blocks'],
+                ['wp-blocks'],
                 filemtime(__DIR__ . '/acf-blocks.js')
             );
             wp_localize_script('sage/acf-blocks.js', 'acfBlockStyles', $styles);


### PR DESCRIPTION
ACF 5.9.0 introduces a JavaScript bug (acf-pro-blocks.min.js : Uncaught TypeError: Cannot read property 'BlockControls' of undefined.). It seems to be because ACF now enqueues wp-blocks differently or in a different order. Removing acf-blocks from the requirement restores a correct order of execution and removes the error while using Gutenberg.