### PR TITLE
Fix relative URLs with Bedrock / Soil

### DIFF
--- a/src/AcfBlock.php
+++ b/src/AcfBlock.php
@@ -85,7 +85,7 @@ class AcfBlock
     {
         return str_replace(
             get_theme_file_path(),
-            get_theme_file_uri(),
+            get_template_directory_uri(),
             $path
         );
     }


### PR DESCRIPTION
The whole issue is already documented here in Soil, but basically, WP_Scripts and WP_Styles can't have relative URLs passed down to them for now.  https://github.com/roots/soil/issues/279