### PR TITLE
Remove Acorn as a required dependency, readme details, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
-# [WIP] Sage ACF Blocks
+# Sage ACF Blocks
 
 A Sage 10 helper package for building ACF blocks rendered using blade templates.
 
 The main difference between this and others similar packages is that it's designed for also rendering the blocks directly from templates that do not have a Block Editor. It also supports rendering different templates per block style.
 
-_Note that this is still in a proof of concept stage. WordPress 5.3 or more is required._.
+_WordPress 5.3 or more is required. A Bedrock installation with Acorn is also required._
 
 ### Installation
 
-1. Install the package in yor theme
+1. If not installed already, add Acorn at the site level in your Bedrocks setup installation
+
+    ```sh
+    composer require roots/acorn
+    ````
+
+2. Install the package in yor theme
 
     ```sh
     composer config repositories.sage-acfblocks vcs https://github.com/generoi/sage-acfblocks.git
     composer require generoi/sage-acfblocks:dev-master
-    ```
+    ```   
 
-2. Add `Generoi\Sage\AcfBlocks\BlockServiceProvider::class` to the providers in `config/app.php` or add automatically with:
+3. Add `Generoi\Sage\AcfBlocks\BlockServiceProvider::class` to the providers in `config/app.php` or add automatically with:
 
     ```sh
     wp acorn package:discover

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,6 @@
       "Genero\\Sage\\AcfBlocks\\": "src/"
     }
   },
-  "require": {
-    "roots/acorn": "*"
-  },
   "require-dev": {
     "squizlabs/php_codesniffer": "~3.0"
   },

--- a/src/AcfBlock.php
+++ b/src/AcfBlock.php
@@ -85,7 +85,7 @@ class AcfBlock
     {
         return str_replace(
             get_theme_file_path(),
-            get_theme_file_uri(),
+            get_template_directory_uri(),
             $path
         );
     }


### PR DESCRIPTION
Hi!

Sage 10 is moving away from requiring Acorn in the theme, but Sage still requires it... they just moved it to be installed at the Bedrock install level. To avoid having conflict with 2 versions installed, we have to remove it from being a requirement in this package, but I took the time to write down extra instructions in the readme.

Plus, I've also closed another pull request that was trailing (the problem with Soil's relative URLs) and actually fixed it properly by using a function that checks for child themes this time (my bad). 

Also, side note: if you don't use this package anymore or if you plan to abandon it, I can take it over if you'd like. I really don't mean to steal your work, but I also feel like I'm nagging you with my updates since I seem to be the only one contributing. 😂  Anyway, just a thought.

Have a nice day! ✌️ 